### PR TITLE
Allow productInfo to be called with different action parameters

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
@@ -707,7 +707,10 @@ public abstract class InstallFeatureUtil {
      */
     private void productInfoValidate() throws PluginExecutionException {
         String output = productInfo(installDirectory, "validate");
-        if (output != null && output.contains("[ERROR]")) {
+        if (output == null) {
+            throw new PluginExecutionException(
+                    "Could not perform product validation. The productInfo command returned with no output");
+        } else if (output.contains("[ERROR]")) {
             throw new PluginExecutionException(output);
         } else {
             info("Product validation completed successfully.");


### PR DESCRIPTION
Allow productInfo to be called with different action parameters.  For validate, check the output for "[ERROR]" since the error code is 0 when validation completes with errors.