### PR TITLE
Skip install map override if openliberty.properties not found

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
@@ -102,9 +102,11 @@ public abstract class InstallFeatureUtil {
     }
 
     private File loadInstallJarFile(File installDirectory) {
-        File installJarOverride = downloadOverrideJar(OPEN_LIBERTY_GROUP_ID, INSTALL_MAP_ARTIFACT_ID);
-        if (installJarOverride != null && installJarOverride.exists()) {
-            return installJarOverride;
+        if (openLibertyVersion != null) {
+            File installJarOverride = downloadOverrideJar(OPEN_LIBERTY_GROUP_ID, INSTALL_MAP_ARTIFACT_ID);
+            if (installJarOverride != null && installJarOverride.exists()) {
+                return installJarOverride;
+            }
         }
         return getMapBasedInstallKernelJar(new File(installDirectory, "lib"));
     }

--- a/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilTest.java
+++ b/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilTest.java
@@ -47,6 +47,38 @@ public class InstallFeatureUtilTest extends BaseInstallFeatureUtilTest {
         new InstallFeatureTestUtil(installDir, null, null, new HashSet<String>());
     }
     
+    /**
+     * No install map - expect a scenario exception
+     */
+    @Test(expected = PluginScenarioException.class)
+    public void testConstructorNoInstallMap() throws Exception {
+        File installMap = new File(installDir, "lib/com.ibm.ws.install.map_1.0.21.jar");
+        assertTrue(installMap.delete());
+        new InstallFeatureTestUtil(installDir, null, null, new HashSet<String>());
+    }
+    
+    /**
+     * No openliberty.properties, but it should find the runtime install map and not encounter an error
+     */
+    @Test
+    public void testConstructorNoOpenLibertyProperties() throws Exception {
+        File olProps = new File(installDir, "lib/versions/openliberty.properties");
+        assertTrue(olProps.delete());
+        new InstallFeatureTestUtil(installDir, null, null, new HashSet<String>());
+    }
+    
+    /**
+     * No install map or openliberty.properties - expect a scenario exception
+     */
+    @Test(expected = PluginScenarioException.class)
+    public void testConstructorNoInstallMapNoOpenLibertyProperties() throws Exception {
+        File olProps = new File(installDir, "lib/versions/openliberty.properties");
+        assertTrue(olProps.delete());
+        File installMap = new File(installDir, "lib/com.ibm.ws.install.map_1.0.21.jar");
+        assertTrue(installMap.delete());
+        new InstallFeatureTestUtil(installDir, null, null, new HashSet<String>());
+    }
+        
     @Test
     public void testConstructorTo() throws Exception {
         InstallFeatureUtil util = new InstallFeatureTestUtil(installDir, null, "myextension", new HashSet<String>());


### PR DESCRIPTION
If openliberty.properties is not found, as is the case in WebSphere Liberty 17.0.0.4, a NullPointerException occurs when trying to load the install map override.  The install map override should be skipped in this case.

```
Caused by: java.lang.NullPointerException
    	at net.wasdev.wlp.common.plugins.util.InstallFeatureUtil.getNextProductVersion(InstallFeatureUtil.java:720)
    	at net.wasdev.wlp.common.plugins.util.InstallFeatureUtil.downloadOverrideJar(InstallFeatureUtil.java:703)
    	at net.wasdev.wlp.common.plugins.util.InstallFeatureUtil.loadInstallJarFile(InstallFeatureUtil.java:105)
    	at net.wasdev.wlp.common.plugins.util.InstallFeatureUtil.<init>(InstallFeatureUtil.java:91)
    	at net.wasdev.wlp.maven.plugins.server.InstallFeatureMojo$InstallFeatureMojoUtil.<init>(InstallFeatureMojo.java:53)
    	at net.wasdev.wlp.maven.plugins.server.InstallFeatureMojo.installFeatures(InstallFeatureMojo.java:121)
    	at net.wasdev.wlp.maven.plugins.server.InstallFeatureMojo.doExecute(InstallFeatureMojo.java:112)
    	at org.codehaus.mojo.pluginsupport.MojoSupport.execute(MojoSupport.java:122)
```