### PR TITLE
Change jaxb dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.2.12</version>
+            <scope>runtime</scope>
         </dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.2.12</version>
         </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Fixes #11 

The maven-plugin-plugin seems to have issues with 2.3.0 of jaxb-api, but does not encounter this error with 2.2.12.  Also, although not directly related to this issue, the jaxb-api is not needed during compilation but only during runtime (since it is only the Liberty runtime that requires it when running with Java 9).