### PR TITLE
Fix NPE when resolved features are empty but no message exists

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
@@ -594,7 +594,11 @@ public abstract class InstallFeatureUtil {
             } else if (resolvedFeatures.isEmpty()) {
                 debug("action.exception.stacktrace: "+mapBasedInstallKernel.get("action.exception.stacktrace"));
                 String exceptionMessage = (String) mapBasedInstallKernel.get("action.error.message");
-                if (exceptionMessage.contains("CWWKF1250I")){
+                if (exceptionMessage == null) {
+                    debug("resolvedFeatures was empty but the install kernel did not issue any messages");
+                    info("The features are already installed, so no action is needed.");
+                    return;
+                } else if (exceptionMessage.contains("CWWKF1250I")) {
                     info(exceptionMessage);
                     info("The features are already installed, so no action is needed.");
                     return;


### PR DESCRIPTION
The install kernel should include a message if the resolved features are empty (in the situation where no features need to be installed).  However, if it does not, we should still consider this as no features need to be installed, and handle it accordingly without NPE.

This addresses https://github.com/WASdev/ci.maven/issues/355