### PR TITLE
Parse server.xml features without usr prefix

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtil.java
@@ -404,7 +404,12 @@ public abstract class InstallFeatureUtil {
             for (int j = 0; j < features.getLength(); j++) {
                 String content = features.item(j).getTextContent();
                 if (content != null) {
-                    result.add(content.trim().toLowerCase());                    
+                    if (content.contains(":")) {
+                        String[] split = content.split(":", 2);
+                        result.add(split[1].trim().toLowerCase());
+                    } else {
+                        result.add(content.trim().toLowerCase());
+                    }
                 }
             }
         }

--- a/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
+++ b/src/test/java/net/wasdev/wlp/common/plugins/util/InstallFeatureUtilGetServerFeaturesTest.java
@@ -507,4 +507,21 @@ public class InstallFeatureUtilGetServerFeaturesTest extends BaseInstallFeatureU
         Files.write(serverXmlPath, content.getBytes(charset));
     }
     
+    /**
+     * Tests server.xml with user features
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUserFeatures() throws Exception{
+        copyAsName("server_user_features.xml", "server.xml");
+
+        Set<String> expected = new HashSet<String>();
+        expected.add("feature1");
+        expected.add("feature2");
+        expected.add("feature3");
+
+        verifyServerFeatures(expected);
+    }
+    
 }

--- a/src/test/resources/servers/server_user_features.xml
+++ b/src/test/resources/servers/server_user_features.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server description="new server">
+    <featureManager>
+        <feature>usr:feature1</feature>
+        <feature>myExt:feature2</feature>
+        <feature>feature3</feature>
+    </featureManager>
+</server>


### PR DESCRIPTION
According to [Liberty documentation](https://www.ibm.com/support/knowledgecenter/en/SSEQTP_liberty/com.ibm.websphere.wlp.doc/ae/cwlp_prod_ext.html), features can be defined in the server.xml with the "usr:" prefix or "_extensionName_:" prefix.  Currently `InstallFeatureUtil` treats the entire string as the feature name.  Instead, it should only use the second part as the feature name.

