### PR TITLE
fixed resourceDir and srcDir bugs and getArtifacts method

### DIFF
--- a/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Scanner;
@@ -133,7 +134,7 @@ public abstract class DevUtil {
     /**
      * Updates artifacts of current project
      */
-    public abstract void getArtifacts(List<String> artifactPaths);
+    public abstract List<String> getArtifacts();
 
     /**
      * Recompile the build file
@@ -395,9 +396,12 @@ public abstract class DevUtil {
                 configFileRegistered = true;
             }
             
+            HashMap<File, Boolean> resourceMap = new HashMap<File, Boolean>();
             for (File resourceDir : resourceDirs) {
+                resourceMap.put(resourceDir, false);
                 if (resourceDir.exists()) {
                     registerAll(resourceDir.toPath(), resourceDir.getCanonicalFile().toPath(), watcher);
+                    resourceMap.replace(resourceDir, true);
                 }
             }
 
@@ -409,7 +413,8 @@ public abstract class DevUtil {
 
             while (true) {
                 // check if javaSourceDirectory has been added
-                if (!sourceDirRegistered && this.sourceDirectory.exists()) {
+                if (!sourceDirRegistered && this.sourceDirectory.exists()
+                        && this.sourceDirectory.listFiles().length > 0) {
                     compile(this.sourceDirectory);
                     registerAll(this.sourceDirectory.toPath(), srcPath, watcher);
                     debug("Registering Java source directory: " + this.sourceDirectory);
@@ -420,12 +425,14 @@ public abstract class DevUtil {
                 }
 
                 // check if testSourceDirectory has been added
-                if (!testSourceDirRegistered && this.testSourceDirectory.exists()) {
+                if (!testSourceDirRegistered && this.testSourceDirectory.exists()
+                        && this.testSourceDirectory.listFiles().length > 0) {
                     compile(this.testSourceDirectory);
                     registerAll(this.testSourceDirectory.toPath(), testSrcPath, watcher);
                     debug("Registering Java test directory: " + this.testSourceDirectory);
                     runTestThread(false, executor, -1, false, false);
                     testSourceDirRegistered = true;
+
                 } else if (testSourceDirRegistered && !this.testSourceDirectory.exists()) {
                     cleanTargetDir(testOutputDirectory);
                     testSourceDirRegistered = false;
@@ -445,6 +452,17 @@ public abstract class DevUtil {
                     info("The server configuration file " + configFile + " has been added. Restart liberty:dev mode for it to take effect.");
                 }
                 
+                // check if resourceDirectory has been added
+                for (File resourceDir : resourceDirs){
+                    if (!resourceMap.get(resourceDir)) {
+                        if (resourceDir.exists()) {
+                            resourceMap.replace(resourceDir, true);
+                            debug("Resource directory has been added: " + resourceDir);
+                            info("The resource directory " + resourceDir + "has been added. Restart liberty:dev mode for it to take effect.");
+                        }
+                    }
+                }
+
                 try {
                     final WatchKey wk = watcher.poll(1, TimeUnit.SECONDS);
                     for (WatchEvent<?> event : wk.pollEvents()) {
@@ -492,7 +510,7 @@ public abstract class DevUtil {
                             if (fileChanged.exists() && fileChanged.getName().endsWith(".java")
                                     && (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
                                             || event.kind() == StandardWatchEventKinds.ENTRY_CREATE)) {
-
+                                
                                 // tests are run in recompileJavaTest
                                 recompileJavaTest(javaFilesChanged, artifactPaths, executor, outputDirectory,
                                         testOutputDirectory);

--- a/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
+++ b/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java
@@ -401,7 +401,7 @@ public abstract class DevUtil {
                 resourceMap.put(resourceDir, false);
                 if (resourceDir.exists()) {
                     registerAll(resourceDir.toPath(), resourceDir.getCanonicalFile().toPath(), watcher);
-                    resourceMap.replace(resourceDir, true);
+                    resourceMap.put(resourceDir, true);
                 }
             }
 
@@ -456,7 +456,7 @@ public abstract class DevUtil {
                 for (File resourceDir : resourceDirs){
                     if (!resourceMap.get(resourceDir)) {
                         if (resourceDir.exists()) {
-                            resourceMap.replace(resourceDir, true);
+                            resourceMap.put(resourceDir, true);
                             debug("Resource directory has been added: " + resourceDir);
                             info("The resource directory " + resourceDir + "has been added. Restart liberty:dev mode for it to take effect.");
                         }

--- a/src/test/java/net/wasdev/wlp/common/plugins/util/BaseDevUtilTest.java
+++ b/src/test/java/net/wasdev/wlp/common/plugins/util/BaseDevUtilTest.java
@@ -90,12 +90,6 @@ public class BaseDevUtilTest {
         }
 
         @Override
-        public void getArtifacts(List<String> artifactPaths) {
-            // TODO Auto-generated method stub
-            
-        }
-
-        @Override
         public boolean recompileBuildFile(File buildFile, List<String> artifactPaths, ThreadPoolExecutor executor) {
             // TODO Auto-generated method stub
             return false;
@@ -124,6 +118,12 @@ public class BaseDevUtilTest {
         public boolean compile(File dir) {
             // TODO Auto-generated method stub
             return false;
+        }
+
+        @Override
+        public List<String> getArtifacts() {
+            // TODO Auto-generated method stub
+            return null;
         }
         
     }


### PR DESCRIPTION
- when registering a newly added source directory or test source directory, register it once there is a file in the folders so that the corresponding classes and test-classes folders are created (https://github.com/kathrynkodama/ci.common/blob/723f746bebd1a439ba8a5c8731ca14545976c6f3/src/main/java/net/wasdev/wlp/common/plugins/util/DevUtil.java#L417)
- getArtifacts method returns a `List<String>`
- "Restart dev mode" message if resource directories are added while dev mode is running